### PR TITLE
change pnpm-lock.yaml merge strategy to text

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 # Don't allow people to merge changes to these generated files, because the result
 # may be invalid.  You need to run "rush update" again.
-pnpm-lock.yaml               merge=binary
+pnpm-lock.yaml               merge=text
 shrinkwrap.yaml              merge=binary
 npm-shrinkwrap.json          merge=binary
 yarn.lock                    merge=binary


### PR DESCRIPTION
since https://github.com/microsoft/rushstack/pull/3137 has already changed the merge strategy to text, rush-example maybe also needs change too